### PR TITLE
chore: add command to llm-mux service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         COMMIT: ${COMMIT:-none}
         BUILD_DATE: ${BUILD_DATE:-unknown}
     container_name: llm-mux
+    command: ["./llm-mux", "--config", "/llm-mux/config.yaml"]
     environment:
       TZ: ${TZ:-UTC}
     ports:


### PR DESCRIPTION
Mình đang chạy dự án mình trên server bằng cách git clone dự án về, khi mình chạy docker thì bằng docker compose up -d thì có log thông báo không tìm thấy config.yaml

=> Mình có thêm dòng này để thêm sử dụng config.yaml trong repo luôn