### PR TITLE
fix(httpapi): update codex models JSON URL to correct path

### DIFF
--- a/internal/httpapi/handle_meta.go
+++ b/internal/httpapi/handle_meta.go
@@ -184,7 +184,7 @@ func anthropicThinkingAliasModels(base []map[string]any) []map[string]any {
 	return aliases
 }
 
-const codexModelsURL = "https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/models.json"
+const codexModelsURL = "https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json"
 
 func openAIModels() []map[string]any {
 	// Try fetching from Codex repo


### PR DESCRIPTION
Because the path to models.json in the Codex repository has changed, it was no longer possible to retrieve the latest model definitions via `/v1/models`.
In this pull request, the path to models.json has been updated to the latest one.